### PR TITLE
fix various typos in macro definitions

### DIFF
--- a/include/esp32_smartdisplay.h
+++ b/include/esp32_smartdisplay.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define ESP32_3248S035C
+
 #include <Arduino.h>
 #include <SPI.h>
 #include <lvgl.h>
@@ -23,7 +25,7 @@ extern void smartdisplay_beep(unsigned int frequency, unsigned long duration);
 extern void smartdisplay_tft_set_backlight(uint16_t duty); // 0-1023 (12 bits)
 // Put the display to sleep
 extern void smartdisplay_tft_sleep();
-// Wake the display 
+// Wake the display
 extern void smartdisplay_tft_wake();
 
 // ESP32_2432S028R
@@ -136,6 +138,6 @@ extern TwoWire i2c_gt911;
 
 // TF Card
 #define TF_PIN_CS 5
-#define TS_PIN_MOSI 23
+#define TF_PIN_MOSI 23
 #define TF_PIN_SCLK 18
 #define TF_PIN_MISC 19

--- a/src/tft_st7796.cpp
+++ b/src/tft_st7796.cpp
@@ -13,7 +13,7 @@
 #define CMD_RAMWR 0x2C   // Memory Write
 #define CMD_MADCTL 0x36  // Memory Data Access Control
 #define CMD_COLMOD 0x3A  // Interface Pixel Format
-#define CMD_PGC 0E0      // Positive Gamma Control
+#define CMD_PGC 0xE0     // Positive Gamma Control
 #define CMD_NGC 0xE1     // Negative Gamma Control
 #define CMD_CSCON 0xF0   // Command Set Control
 


### PR DESCRIPTION
Includes the following commits:

- [x] [fix macro identifiers for TF card pinout](https://github.com/rzeldent/esp32-smartdisplay/commit/8eb275da460e8e33cb2feb266711ba1ff2532a6b)
	> These identifiers seem to be unused, so no other changes are necessary to accomodate.
- [x] [fix accidental floating-point macro definition](https://github.com/rzeldent/esp32-smartdisplay/commit/45094cf691728953d2f7be417e7132129a7cdc06)
	> These macros should all be 8-bit commands recognized by ST7796 IC, conventionally expressed in hexadecimal. Unfortunately, the base prefix "0x" ommitted the "x". And, to make it worse, the hex value "E0" just happens to be the syntax used to express floating-point literals in exponential notation! So, everywhere this symbol intended to represent "0xE0" (decimal "224"), it instead used "0E0" (a double-precision floating point literal "0.0")
