### PR TITLE
Feature/flipped display

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
         smartboard: ["-DESP32_2432S024N", "-DESP32_2432S024R", "-DESP32_2432S024C", "-DESP32_2432S028R", "-DESP32_3248S035R", "-DESP32_3248S035C", "-DESP32_8048S070N", "-DESP32_8048S070C"]
         orientation: ["-DTFT_ORIENTATION_PORTRAIT", "-DTFT_ORIENTATION_LANDSCAPE", "-DTFT_ORIENTATION_PORTRAIT_INV", "-DTFT_ORIENTATION_LANDSCAPE_INV"]
         rgborder: ["-DTFT_PANEL_ORDER_RGB", "-DTFT_PANEL_ORDER_BGR"]
-        mirrored: ["", "-DTFT_MIRRORED"]
+        flippedmirrored: ["", "-DTFT_FLIPPEDMIRRORED"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up python
@@ -22,7 +22,7 @@ jobs:
       - name: Build firmware
         run: pio ci --lib="." --board esp32dev "examples/lvgl_pushbutton/main.cpp"
         env:
-          PLATFORMIO_BUILD_FLAGS: -Ofast -DLV_CONF_PATH="${{github.workspace}}/examples/lvgl_pushbutton/lv_conf.h" ${{matrix.smartboard}} ${{matrix.orientation}} ${{matrix.rgborder}} ${{matrix.mirrored}}
+          PLATFORMIO_BUILD_FLAGS: -Ofast -DLV_CONF_PATH="${{github.workspace}}/examples/lvgl_pushbutton/lv_conf.h" ${{matrix.smartboard}} ${{matrix.orientation}} ${{matrix.rgborder}} ${{matrix.flippedmirrored}}
       - name: Archive
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smartboard: ["ESP32_2432S024N", "ESP32_2432S024R", "ESP32_2432S024C", "ESP32_2432S028R", "ESP32_3248S035R", "ESP32_3248S035C", "ESP32_8048S070N", "ESP32_8048S070C"]
-        orientation: ["TFT_ORIENTATION_PORTRAIT", "TFT_ORIENTATION_LANDSCAPE", "TFT_ORIENTATION_PORTRAIT_INV", "TFT_ORIENTATION_LANDSCAPE_INV"]
-        rgborder: ["TFT_PANEL_ORDER_RGB", "TFT_PANEL_ORDER_BGR"]
+        smartboard: ["-DESP32_2432S024N", "-DESP32_2432S024R", "-DESP32_2432S024C", "-DESP32_2432S028R", "-DESP32_3248S035R", "-DESP32_3248S035C", "-DESP32_8048S070N", "-DESP32_8048S070C"]
+        orientation: ["-DTFT_ORIENTATION_PORTRAIT", "-DTFT_ORIENTATION_LANDSCAPE", "-DTFT_ORIENTATION_PORTRAIT_INV", "-DTFT_ORIENTATION_LANDSCAPE_INV"]
+        rgborder: ["-DTFT_PANEL_ORDER_RGB", "-DTFT_PANEL_ORDER_BGR"]
+        mirrored: ["", "-DTFT_MIRRORED"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up python
@@ -21,7 +22,7 @@ jobs:
       - name: Build firmware
         run: pio ci --lib="." --board esp32dev "examples/lvgl_pushbutton/main.cpp"
         env:
-          PLATFORMIO_BUILD_FLAGS: -Ofast -D LV_CONF_PATH="${{github.workspace}}/examples/lvgl_pushbutton/lv_conf.h" -D ${{matrix.orientation}} -D ${{matrix.smartboard}} -D ${{matrix.rgborder}}
+          PLATFORMIO_BUILD_FLAGS: -Ofast -DLV_CONF_PATH="${{github.workspace}}/examples/lvgl_pushbutton/lv_conf.h" ${{matrix.smartboard}} ${{matrix.orientation}} ${{matrix.rgborder}} ${{matrix.mirrored}}
       - name: Archive
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To have all the constants and prototypes from LVGL, the LVGL library is already 
 
 - LVGL (version ^8.3.2)
 
-To use the LVGL library, a ```lv_conf.h``` file is required to define the settings for LVGL.
+To use the LVGL library, a `lv_conf.h` file is required to define the settings for LVGL.
 This file needs to be provided by the application.
 As this file is referenced from the build of LVGL, the path must be known.
 Normally this file is included in the include directory of your project so the define must be
@@ -62,13 +62,14 @@ Normally this file is included in the include directory of your project so the d
     -D LV_CONF_PATH=${PROJECT_INCLUDE_DIR}/lv_conf.h
 ```
 
-The template for the ```lv_conf.h``` file can be found in the LVGL library at ```.pio/libdeps/esp32dev/lvgl/lv_conf_template.h```.
+The template for the `lv_conf.h` file can be found in the LVGL library at `.pio/libdeps/esp32dev/lvgl/lv_conf_template.h`.
 
 ## How to use
 
 Basically there is only **ONE** define that need to be defined: The type of board assuming everything is default.
 
 - Type of board (required)
+
   - ESP32_2432S024R
   - ESP32_2432S024C
   - ESP32_2432S024N
@@ -79,16 +80,21 @@ Basically there is only **ONE** define that need to be defined: The type of boar
   - ESP32_8048S070C
 
 - Orientation of the board (optional)
+
   - TFT_ORIENTATION_PORTRAIT (default)
   - TFT_ORIENTATION_LANDSCAPE (rotated 90 degrees)
   - TFT_ORIENTATION_PORTRAIT_INV (rotated 180 degrees)
   - TFT_ORIENTATION_LANDSCAPE_INV (rotated 270/-90 degrees)
 
+- Mirrored (optional)
+  Some TFT batches seem to have the contents mirrored (vertical orientation flipped).
+  The flag TFT_MIRRORED compensates for this anomaly.
+
 - LCD Panel RGB order (if red and blue are swapped on the display, optional)
   - TFT_PANEL_ORDER_RGB
   - TFT_PANEL_ORDER_BGR (default)
 
-These can be defined in the ```platformio.ini``` file defining the settings:
+These can be defined in the `platformio.ini` file defining the settings:
 
 ```ini
 build_flags =
@@ -101,6 +107,7 @@ build_flags =
     #-D TFT_ORIENTATION_LANDSCAPE
     #-D TFT_ORIENTATION_PORTRAIT_INV
     #-D TFT_ORIENTATION_LANDSCAPE_INV
+    #-D TFT_MIRRORED
     #-D ESP32_2432S024N
     #-D ESP32_2432S024R
     -D ESP32_2432S024C
@@ -111,10 +118,10 @@ build_flags =
     #-D ESP32_8048S070C
 
 lib_deps =
-    rzeldent/esp32_smartdisplay@^1.0.6
+    rzeldent/esp32_smartdisplay@^1.0.9
 ```
 
-The path for the lv_conf.h above is ```${PROJECT_INCLUDE_DIR}```.
+The path for the lv_conf.h above is `${PROJECT_INCLUDE_DIR}`.
 This needs to be specified because the LVGL library included this header file.
 
 ## Demo application
@@ -175,9 +182,11 @@ Put the display to sleep.
 Wake the display.
 
 ## Version history
+
 - October 2023
+  - Added option for mirrored TFT's
   - Changed default RGB order to BGR
-  - Version 1.0.8
+  - Version 1.0.8 and 1.0.9
 - September 2023
   - Added support for ESP32_2432S024N/R/S
   - Version 1.0.7

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Basically there is only **ONE** define that need to be defined: The type of boar
   - TFT_ORIENTATION_PORTRAIT_INV (rotated 180 degrees)
   - TFT_ORIENTATION_LANDSCAPE_INV (rotated 270/-90 degrees)
 
-- Mirrored (optional)
-  Some TFT batches seem to have the contents mirrored (vertical orientation flipped).
-  The flag TFT_MIRRORED compensates for this anomaly.
+- Flipped/Mirrored (optional)
+  Some TFT batches seem to have the contents mirrored and flipped.
+  The flag TFT_FLIPPEDMIRRORED compensates for this (production?) anomaly.
 
 - LCD Panel RGB order (if red and blue are swapped on the display, optional)
   - TFT_PANEL_ORDER_RGB
@@ -107,10 +107,10 @@ build_flags =
     #-D TFT_ORIENTATION_LANDSCAPE
     #-D TFT_ORIENTATION_PORTRAIT_INV
     #-D TFT_ORIENTATION_LANDSCAPE_INV
-    #-D TFT_MIRRORED
+    #-D TFT_FLIPPEDMIRRORED
     #-D ESP32_2432S024N
     #-D ESP32_2432S024R
-    -D ESP32_2432S024C
+    #-D ESP32_2432S024C
     #-D ESP32_2432S028R
     #-D ESP32_3248S035R
     #-D ESP32_3248S035C
@@ -184,7 +184,7 @@ Wake the display.
 ## Version history
 
 - October 2023
-  - Added option for mirrored TFT's
+  - Added option for flipped/mirrored TFT's
   - Changed default RGB order to BGR
   - Version 1.0.8 and 1.0.9
 - September 2023

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "esp32_smartdisplay",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "LVGL driver for Sunton ESP32 TFT display boards",
     "keywords": "LVGL 2432S024 2432S028 3248S035 8048S070",
     "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=esp32-smartdisplay
-version=1.0.8
+version=1.0.9
 author=Rene Zeldenthuis
 maintainer=Rene Zeldenthuis
 category=Displays & LEDs

--- a/src/tft_ilI9341.cpp
+++ b/src/tft_ilI9341.cpp
@@ -113,34 +113,34 @@ void ili9341_send_init_commands()
 
 #ifdef TFT_ORIENTATION_PORTRAIT
 // Portrait 0 Degrees
-#ifndef TFT_MIRRORED
+#ifndef TFT_FLIPPEDMIRRORED
   static const uint8_t madctl[] = {MADCTL_MY | MADCTL_PANEL_ORDER};
 #else
-  static const uint8_t madctl[] = {MADCTL_MY | MADCTL_MV | MADCTL_PANEL_ORDER}; // Mirrored
+  static const uint8_t madctl[] = {MADCTL_MY | MADCTL_MV | MADCTL_PANEL_ORDER}; // Flipped/Mirrored anomaly
 #endif
 #else
 #ifdef TFT_ORIENTATION_LANDSCAPE
 // Landscape 90 Degrees
-#ifndef TFT_MIRRORED
+#ifndef TFT_FLIPPEDMIRRORED
   static const uint8_t madctl[] = {MADCTL_MV | MADCTL_PANEL_ORDER};
 #else
-  static const uint8_t madctl[] = {MADCTL_ML | MADCTL_PANEL_ORDER}; // Mirrored
+  static const uint8_t madctl[] = {MADCTL_ML | MADCTL_PANEL_ORDER}; // Flipped/Mirrored anomaly
 #endif
 #else
 #ifdef TFT_ORIENTATION_PORTRAIT_INV
 // Portrait inverted 180 Degrees
-#ifndef TFT_MIRRORED
+#ifndef TFT_FLIPPEDMIRRORED
   static const uint8_t madctl[] = {MADCTL_MX | MADCTL_PANEL_ORDER};
 #else
-  static const uint8_t madctl[] = {MADCTL_MX | MADCTL_MV | MADCTL_PANEL_ORDER}; // Mirrored
+  static const uint8_t madctl[] = {MADCTL_MX | MADCTL_MV | MADCTL_PANEL_ORDER}; // Flipped/Mirrored anomaly
 #endif
 #else
 #ifdef TFT_ORIENTATION_LANDSCAPE_INV
 // Landscape inverted 270 Degrees
-#ifndef TFT_MIRRORED
+#ifndef TFT_FLIPPEDMIRRORED
   static const uint8_t madctl[] = {MADCTL_MY | MADCTL_MX | MADCTL_MV | MADCTL_PANEL_ORDER};
 #else
-  static const uint8_t madctl[] = {MADCTL_MY | MADCTL_MX | MADCTL_MH | MADCTL_PANEL_ORDER}; // Mirrored
+  static const uint8_t madctl[] = {MADCTL_MY | MADCTL_MX | MADCTL_MH | MADCTL_PANEL_ORDER}; // Flipped/Mirrored anomaly
 #endif
 #else
 #error TFT_ORIENTATION not defined!


### PR DESCRIPTION
Added option for flipped/mirrored TFT's. Unclear why this happens  on some TFT's but seems to be a production issue?

Option is TFT_FLIPPEDMIRRORED.

Thanks to users [ruppelito](https://github.com/truppelito) and [Curtiss02](https://github.com/Curtiss02) for assisting in resolving this issue.
