### PR TITLE
Fix for new ESP-IDF Arduino core 3.0.0

### DIFF
--- a/include/esp32_smartdisplay.h
+++ b/include/esp32_smartdisplay.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <SPI.h>
 #include <lvgl.h>
+#include <esp_arduino_version.h>
 #if defined(ESP32_2432S024C) || defined(ESP32_3248S035C) || defined(ESP32_8048S070C)
 #include <Wire.h>
 #endif

--- a/src/esp32_smartdisplay.cpp
+++ b/src/esp32_smartdisplay.cpp
@@ -66,6 +66,20 @@ void smartdisplay_init()
   const std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
   // Setup RGB LED.  High is off
   // Use channel 0=R, 1=G, 2=B, 5kHz,  8 bit resolution
+
+#if ESP_ARDUINO_VERSION_MAJOR  >=3
+  pinMode(LED_PIN_R, OUTPUT);
+  digitalWrite(LED_PIN_R, true);
+  ledcAttach(LED_PIN_R, LED_PWM_FREQ, LED_PWM_BITS);
+
+  pinMode(LED_PIN_G, OUTPUT);
+  digitalWrite(LED_PIN_G, true);
+  ledcAttach(LED_PIN_G, LED_PWM_FREQ, LED_PWM_BITS);
+
+  pinMode(LED_PIN_B, OUTPUT);
+  digitalWrite(LED_PIN_B, true);
+  ledcAttach(LED_PIN_B, LED_PWM_FREQ, LED_PWM_BITS);
+#else
   pinMode(LED_PIN_R, OUTPUT);
   digitalWrite(LED_PIN_R, true);
   ledcSetup(LED_PWM_CHANNEL_R, LED_PWM_FREQ, LED_PWM_BITS);
@@ -80,6 +94,7 @@ void smartdisplay_init()
   digitalWrite(LED_PIN_B, true);
   ledcSetup(LED_PWM_CHANNEL_B, LED_PWM_FREQ, LED_PWM_BITS);
   ledcAttachPin(LED_PIN_B, LED_PWM_CHANNEL_B);
+#endif
 
   // Setup CDS Light sensor
   analogSetAttenuation(ADC_0db); // 0dB(1.0x) 0~800mV
@@ -172,9 +187,15 @@ void smartdisplay_init()
 
 void smartdisplay_set_led_color(lv_color32_t rgb)
 {
-  ledcWrite(LED_PWM_CHANNEL_R, LED_PWM_MAX - rgb.ch.red);
-  ledcWrite(LED_PWM_CHANNEL_G, LED_PWM_MAX - rgb.ch.green);
-  ledcWrite(LED_PWM_CHANNEL_B, LED_PWM_MAX - rgb.ch.blue);
+  #if ESP_ARDUINO_VERSION_MAJOR  >=3
+    ledcWrite(LED_PIN_R, LED_PWM_MAX - rgb.ch.red);
+    ledcWrite(LED_PIN_G, LED_PWM_MAX - rgb.ch.green);
+    ledcWrite(LED_PIN_B, LED_PWM_MAX - rgb.ch.blue);
+  #else 
+    ledcWrite(LED_PWM_CHANNEL_R, LED_PWM_MAX - rgb.ch.red);
+    ledcWrite(LED_PWM_CHANNEL_G, LED_PWM_MAX - rgb.ch.green);
+    ledcWrite(LED_PWM_CHANNEL_B, LED_PWM_MAX - rgb.ch.blue);
+  #endif
 }
 
 int smartdisplay_get_light_intensity()

--- a/src/tft_ilI9341.cpp
+++ b/src/tft_ilI9341.cpp
@@ -177,8 +177,12 @@ void lvgl_tft_init()
   digitalWrite(ILI9341_PIN_CS, HIGH);
 
   pinMode(ILI9341_PIN_BL, OUTPUT); // Backlight
-  ledcSetup(ILI9341_PWM_CHANNEL_BL, ILI9341_PWM_FREQ_BL, ILI9341_PWM_BITS_BL);
-  ledcAttachPin(ILI9341_PIN_BL, ILI9341_PWM_CHANNEL_BL);
+  #if ESP_ARDUINO_VERSION_MAJOR  >=3
+    ledcAttach(ILI9341_PIN_BL, ILI9341_PWM_FREQ_BL, ILI9341_PWM_BITS_BL);
+  #else 
+    ledcSetup(ILI9341_PWM_CHANNEL_BL, ILI9341_PWM_FREQ_BL, ILI9341_PWM_BITS_BL);
+    ledcAttachPin(ILI9341_PIN_BL, ILI9341_PWM_CHANNEL_BL);
+  #endif
 
   ili9341_send_init_commands();
 
@@ -209,7 +213,12 @@ void lvgl_tft_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color
 
 void smartdisplay_tft_set_backlight(uint16_t duty)
 {
-  ledcWrite(ILI9341_PWM_CHANNEL_BL, duty);
+  #if ESP_ARDUINO_VERSION_MAJOR  >=3
+    ledcWrite(ILI9341_PIN_BL, duty);
+  #else 
+    ledcWrite(ILI9341_PWM_CHANNEL_BL, duty);
+  #endif
+  
 }
 
 void smartdisplay_tft_sleep()

--- a/src/tft_st7796.cpp
+++ b/src/tft_st7796.cpp
@@ -132,8 +132,13 @@ void lvgl_tft_init()
   digitalWrite(ST7796_PIN_CS, HIGH);
 
   pinMode(ST7796_PIN_BL, OUTPUT); // Backlight
-  ledcSetup(ST7796_PWM_CHANNEL_BL, ST7796_PWM_FREQ_BL, ST7796_PWM_BITS_BL);
-  ledcAttachPin(ST7796_PIN_BL, ST7796_PWM_CHANNEL_BL);
+
+    #if ESP_ARDUINO_VERSION_MAJOR  >=3
+    ledcAttach(ST7796_PIN_BL, ST7796_PWM_FREQ_BL, ST7796_PWM_BITS_BL);
+  #else 
+    ledcSetup(ST7796_PWM_CHANNEL_BL, ST7796_PWM_FREQ_BL, ST7796_PWM_BITS_BL);
+    ledcAttachPin(ST7796_PIN_BL, ST7796_PWM_CHANNEL_BL);
+  #endif
 
   st7796_send_init_commands();
 
@@ -164,7 +169,11 @@ void lvgl_tft_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color
 
 void smartdisplay_tft_set_backlight(uint16_t duty)
 {
-  ledcWrite(ST7796_PWM_CHANNEL_BL, duty);
+  #if ESP_ARDUINO_VERSION_MAJOR  >=3
+    ledcWrite(ST7796_PIN_BL, duty);
+  #else 
+    ledcWrite(ST7796_PWM_CHANNEL_BL, duty);
+  #endif
 }
 
 void smartdisplay_tft_sleep()


### PR DESCRIPTION
The new ESP-IDF 5.1 - Arduino Core 3.0.0 has some breaking changes regarding ledc component.
With these changes one can compile on updated installations.
