### PR TITLE
Use LVGL pixel buffer size and malloc flags for json

### DIFF
--- a/include/esp32_smartdisplay.h
+++ b/include/esp32_smartdisplay.h
@@ -4,9 +4,6 @@
 #include <Arduino.h>
 #include <lvgl.h>
 
-// LVGL lines buffered
-#define LVGL_PIXEL_BUFFER_LINES 16
-
 // Use last PWM_CHANNEL for backlight
 #define PWM_CHANNEL_BCKL (SOC_LEDC_CHANNEL_NUM - 1)
 #define PWM_FREQ_BCKL 20000

--- a/src/esp32_smartdisplay.c
+++ b/src/esp32_smartdisplay.c
@@ -249,9 +249,8 @@ void smartdisplay_init()
   disp_drv.ver_res = LCD_HEIGHT;
   // Create drawBuffer
   disp_drv.draw_buf = (lv_disp_draw_buf_t *)malloc(sizeof(lv_disp_draw_buf_t));
-  uint drawBufferPixels = LCD_WIDTH * LVGL_PIXEL_BUFFER_LINES;
-  void *drawBuffer = heap_caps_malloc(sizeof(lv_color16_t) * drawBufferPixels, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-  lv_disp_draw_buf_init(disp_drv.draw_buf, drawBuffer, NULL, drawBufferPixels);
+  void *drawBuffer = heap_caps_malloc(sizeof(lv_color16_t) * LVGL_BUFFER_PIXELS, LVGL_BUFFER_MALLOC_FLAGS);
+  lv_disp_draw_buf_init(disp_drv.draw_buf, drawBuffer, NULL, LVGL_BUFFER_PIXELS);
   // Initialize specific driver
   lvgl_lcd_init(&disp_drv);
   lv_disp_t *display = lv_disp_drv_register(&disp_drv);


### PR DESCRIPTION
Use the settings for the pixelbuffer and malloc options from the json file.
This allows to use SPI ram and adjust the buffer size