### PR TITLE
Fix #ifdef vs #if

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,14 +383,14 @@ Some boards are around that have flipped screens, this is probably due to differ
 
 To adjust the display and touch to the default (LV_DISP_ROT_NONE) there are 6 defines in the boards definition:
 
-| Name            | Description   |
-|---              |---      |
-| DISPLAY_SWAP_XY     | Swaps the X and Y coordinates for the display |
-| DISPLAY_MIRROR_X    | Mirrors the X coordinate for the display      |
-| DISPLAY_MIRROR_Y    | Mirrors the Y coordinate for the display      |
-| TOUCH_SWAP_XY   | Swaps the X and Y coordinates for the touch   |
-| TOUCH_MIRROR_X  | Mirrors the X coordinate for the touch        |
-| TOUCH_MIRROR_Y  | Mirrors the Y coordinate for the touch        |
+| Name              | Description   |
+|---                |---      |
+| DISPLAY_SWAP_XY   | Swaps the X and Y coordinates for the display |
+| DISPLAY_MIRROR_X  | Mirrors the X coordinate for the display      |
+| DISPLAY_MIRROR_Y  | Mirrors the Y coordinate for the display      |
+| TOUCH_SWAP_XY     | Swaps the X and Y coordinates for the touch   |
+| TOUCH_MIRROR_X    | Mirrors the X coordinate for the touch        |
+| TOUCH_MIRROR_Y    | Mirrors the Y coordinate for the touch        |
 
 
 ## Appendix: Template to support ALL the boards

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,7 @@
 #default_envs = esp32-8048S070C
 #default_envs = esp32-8048S070N
 #default_envs = esp32-8048S070R
+#default_envs = esp32-s3touchlcd7
 
 [env]
 platform = espressif32
@@ -153,3 +154,6 @@ board = esp32-8048S070N
 
 [env:esp32-8048S070R]
 board = esp32-8048S070R
+
+[env:esp32-s3touchlcd7]
+boards = esp32-s3touchlcd7

--- a/src/lvgl_panel_gc9a01_spi.c
+++ b/src/lvgl_panel_gc9a01_spi.c
@@ -88,13 +88,13 @@ void lvgl_lcd_init(lv_disp_drv_t *drv)
     // If LCD is IPS invert the colors
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
 #endif
-#ifdef DISPLAY_SWAP_XY
+#if (DISPLAY_SWAP_XY)
     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
 #endif
-#if defined(DISPLAY_MIRROR_X) || defined(DISPLAY_MIRROR_Y)    
+#if (DISPLAY_MIRROR_X || DISPLAY_MIRROR_Y)    
     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
 #endif    
-#if defined(DISPLAY_GAP_X) || defined(DISPLAY_GAP_Y)
+#if (DISPLAY_GAP_X || DISPLAY_GAP_Y)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, DISPLAY_GAP_X, DISPLAY_GAP_Y));
 #endif
     // Turn display on

--- a/src/lvgl_panel_ili9341_spi.c
+++ b/src/lvgl_panel_ili9341_spi.c
@@ -84,13 +84,13 @@ void lvgl_lcd_init(lv_disp_drv_t *drv)
     // If LCD is IPS invert the colors
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
 #endif
-#ifdef DISPLAY_SWAP_XY
+#if (DISPLAY_SWAP_XY)
     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
 #endif
-#if defined(DISPLAY_MIRROR_X) || defined(DISPLAY_MIRROR_Y)    
+#if (DISPLAY_MIRROR_X || DISPLAY_MIRROR_Y)    
     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
 #endif    
-#if defined(DISPLAY_GAP_X) || defined(DISPLAY_GAP_Y)
+#if (DISPLAY_GAP_X || DISPLAY_GAP_Y)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, DISPLAY_GAP_X, DISPLAY_GAP_Y));
 #endif
     // Turn display on

--- a/src/lvgl_panel_st7789_spi.c
+++ b/src/lvgl_panel_st7789_spi.c
@@ -84,13 +84,13 @@ void lvgl_lcd_init(lv_disp_drv_t *drv)
     // If LCD is IPS invert the colors
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
 #endif
-#ifdef DISPLAY_SWAP_XY
+#if (DISPLAY_SWAP_XY)
     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
 #endif
-#if defined(DISPLAY_MIRROR_X) || defined(DISPLAY_MIRROR_Y)    
+#if (DISPLAY_MIRROR_X || DISPLAY_MIRROR_Y)    
     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
 #endif    
-#if defined(DISPLAY_GAP_X) || defined(DISPLAY_GAP_Y)
+#if (DISPLAY_GAP_X || DISPLAY_GAP_Y)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, DISPLAY_GAP_X, DISPLAY_GAP_Y));
 #endif
     // Turn display on

--- a/src/lvgl_panel_st7796_spi.c
+++ b/src/lvgl_panel_st7796_spi.c
@@ -85,13 +85,13 @@ void lvgl_lcd_init(lv_disp_drv_t *drv)
     // If LCD is IPS invert the colors
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
 #endif
-#ifdef DISPLAY_SWAP_XY
+#if (DISPLAY_SWAP_XY)
     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
 #endif
-#if defined(DISPLAY_MIRROR_X) || defined(DISPLAY_MIRROR_Y)    
+#if (DISPLAY_MIRROR_X || DISPLAY_MIRROR_Y)    
     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
 #endif    
-#if defined(DISPLAY_GAP_X) || defined(DISPLAY_GAP_Y)
+#if (DISPLAY_GAP_X || DISPLAY_GAP_Y)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, DISPLAY_GAP_X, DISPLAY_GAP_Y));
 #endif
     // Turn display on


### PR DESCRIPTION
Because the DISPLAY_SWAP_XY, DISPLAY_MIRROR_X  and DISPLAY_MIRROR_Y are defined as false/true, the #ifdef is always true.

This should not be the case but evaluated. To have values instead of just a define is desirable because these are also used for the software rotation