### PR TITLE
Remove sw_rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,8 @@ The following libraries are used from the [Espressif component registry](https:/
 
 ## Version history
 
+- October 2024
+  - Fix for LVGL 9.2.2 that removed the sw_rotate flag
 - August 2024
   - LVGL 9.2
   - New boards

--- a/library.json
+++ b/library.json
@@ -35,6 +35,6 @@
     "frameworks": "arduino",
     "platforms": "espressif32",
     "dependencies": {
-        "lvgl/lvgl": "9.2.0"
+        "lvgl/lvgl": "^9.2.1"
     }
 }

--- a/library.json
+++ b/library.json
@@ -35,6 +35,6 @@
     "frameworks": "arduino",
     "platforms": "espressif32",
     "dependencies": {
-        "lvgl/lvgl": "^9.2.1"
+        "lvgl/lvgl": "^9.2.2"
     }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@
 #default_envs = esp32-4827S043C
 #default_envs = esp32-4827S043N
 #default_envs = esp32-4827S043R
-#default_envs = esp32-4848S040CIY1
+default_envs = esp32-4848S040CIY1
 #default_envs = esp32-4848S040CIY3
 #default_envs = esp32-8048S043C
 #default_envs = esp32-8048S043N
@@ -59,7 +59,7 @@ build_flags =
     '-D ESP_LCD_PANEL_IO_ADDITIONS_VER_PATCH=1'
 
 lib_deps =
-    lvgl/lvgl@^9.2.1
+    lvgl/lvgl@^9.2.2
     # The platformio.test_dir contains the test_main.cpp just to have an setup() and loop() function
     # so it will compile
     ${platformio.test_dir}

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@
 #default_envs = esp32-4827S043C
 #default_envs = esp32-4827S043N
 #default_envs = esp32-4827S043R
-default_envs = esp32-4848S040CIY1
+#default_envs = esp32-4848S040CIY1
 #default_envs = esp32-4848S040CIY3
 #default_envs = esp32-8048S043C
 #default_envs = esp32-8048S043N

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ build_flags =
     '-D ESP_LCD_PANEL_IO_ADDITIONS_VER_PATCH=1'
 
 lib_deps =
-    lvgl/lvgl@9.2.0
+    lvgl/lvgl@^9.2.1
     # The platformio.test_dir contains the test_main.cpp just to have an setup() and loop() function
     # so it will compile
     ${platformio.test_dir}

--- a/src/esp32_smartdisplay.c
+++ b/src/esp32_smartdisplay.c
@@ -193,9 +193,6 @@ void smartdisplay_init()
 #endif
   // Setup TFT display
   display = lvgl_lcd_init();
-  // Register callback for hardware rotation
-  // if (!display->sw_rotate)
-  //   lv_display_add_event_cb(display, lvgl_display_resolution_changed_callback, LV_EVENT_RESOLUTION_CHANGED, NULL);
 
   //  Clear screen
   lv_obj_clean(lv_scr_act());
@@ -213,31 +210,3 @@ void smartdisplay_init()
   lv_indev_enable(indev, true);
 #endif
 }
-
-// Called when driver resolution is updated (including rotation)
-// Top of the display is top left when connector is at the bottom
-// The rotation values are relative to how you would rotate the physical display in the clockwise direction.
-// Thus, LV_DISPLAY_ROTATION_90 means you rotate the hardware 90 degrees clockwise, and the display rotates 90 degrees counterclockwise to compensate.
-// void lvgl_display_resolution_changed_callback(lv_event_t *event)
-// {
-//   const esp_lcd_panel_handle_t panel_handle = display->user_data;
-//   switch (display->rotation)
-//   {
-//   case LV_DISPLAY_ROTATION_0:
-//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
-//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
-//     break;
-//   case LV_DISPLAY_ROTATION_90:
-//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
-//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
-//     break;
-//   case LV_DISPLAY_ROTATION_180:
-//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
-//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
-//     break;
-//   case LV_DISPLAY_ROTATION_270:
-//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
-//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
-//     break;
-//   }
-// }

--- a/src/esp32_smartdisplay.c
+++ b/src/esp32_smartdisplay.c
@@ -194,8 +194,8 @@ void smartdisplay_init()
   // Setup TFT display
   display = lvgl_lcd_init();
   // Register callback for hardware rotation
-  if (!display->sw_rotate)
-    lv_display_add_event_cb(display, lvgl_display_resolution_changed_callback, LV_EVENT_RESOLUTION_CHANGED, NULL);
+  // if (!display->sw_rotate)
+  //   lv_display_add_event_cb(display, lvgl_display_resolution_changed_callback, LV_EVENT_RESOLUTION_CHANGED, NULL);
 
   //  Clear screen
   lv_obj_clean(lv_scr_act());
@@ -218,26 +218,26 @@ void smartdisplay_init()
 // Top of the display is top left when connector is at the bottom
 // The rotation values are relative to how you would rotate the physical display in the clockwise direction.
 // Thus, LV_DISPLAY_ROTATION_90 means you rotate the hardware 90 degrees clockwise, and the display rotates 90 degrees counterclockwise to compensate.
-void lvgl_display_resolution_changed_callback(lv_event_t *event)
-{
-  const esp_lcd_panel_handle_t panel_handle = display->user_data;
-  switch (display->rotation)
-  {
-  case LV_DISPLAY_ROTATION_0:
-    ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
-    ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
-    break;
-  case LV_DISPLAY_ROTATION_90:
-    ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
-    ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
-    break;
-  case LV_DISPLAY_ROTATION_180:
-    ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
-    ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
-    break;
-  case LV_DISPLAY_ROTATION_270:
-    ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
-    ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
-    break;
-  }
-}
+// void lvgl_display_resolution_changed_callback(lv_event_t *event)
+// {
+//   const esp_lcd_panel_handle_t panel_handle = display->user_data;
+//   switch (display->rotation)
+//   {
+//   case LV_DISPLAY_ROTATION_0:
+//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
+//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
+//     break;
+//   case LV_DISPLAY_ROTATION_90:
+//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
+//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
+//     break;
+//   case LV_DISPLAY_ROTATION_180:
+//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, DISPLAY_SWAP_XY));
+//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, !DISPLAY_MIRROR_Y));
+//     break;
+//   case LV_DISPLAY_ROTATION_270:
+//     ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, !DISPLAY_SWAP_XY));
+//     ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, !DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
+//     break;
+//   }
+// }

--- a/src/lvgl_panel_gc9a01_spi.c
+++ b/src/lvgl_panel_gc9a01_spi.c
@@ -17,6 +17,7 @@ bool gc9a01_color_trans_done(esp_lcd_panel_io_handle_t panel_io_handle, esp_lcd_
 
 void gc9a01_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is supported
     log_v("display:0x%08x, area:%0x%08x, color_map:0x%08x", display, area, px_map);
 
     esp_lcd_panel_handle_t panel_handle = display->user_data;
@@ -39,10 +40,6 @@ lv_display_t *lvgl_lcd_init()
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is supported
-//    display->sw_rotate = 0;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus
     const spi_bus_config_t spi_bus_config = {

--- a/src/lvgl_panel_gc9a01_spi.c
+++ b/src/lvgl_panel_gc9a01_spi.c
@@ -41,7 +41,7 @@ lv_display_t *lvgl_lcd_init()
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is supported
-    display->sw_rotate = 0;
+//    display->sw_rotate = 0;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus

--- a/src/lvgl_panel_ili9341_spi.c
+++ b/src/lvgl_panel_ili9341_spi.c
@@ -37,7 +37,7 @@ lv_display_t *lvgl_lcd_init()
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is supported
-    display->sw_rotate = 0;
+//    display->sw_rotate = 0;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus

--- a/src/lvgl_panel_ili9341_spi.c
+++ b/src/lvgl_panel_ili9341_spi.c
@@ -15,6 +15,7 @@ bool ili9341_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_
 
 void ili9341_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is supported
     esp_lcd_panel_handle_t panel_handle = display->user_data;
     uint32_t pixels = lv_area_get_size(area);
     uint16_t *p = (uint16_t *)px_map;
@@ -35,10 +36,6 @@ lv_display_t *lvgl_lcd_init()
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is supported
-//    display->sw_rotate = 0;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus
     const spi_bus_config_t spi_bus_config = {

--- a/src/lvgl_panel_st7262_par.c
+++ b/src/lvgl_panel_st7262_par.c
@@ -69,7 +69,7 @@ lv_display_t *lvgl_lcd_init()
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is not supported
-    display->sw_rotate = 1;
+    //display->sw_rotate = 1;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create direct_io panel handle

--- a/src/lvgl_panel_st7262_par.c
+++ b/src/lvgl_panel_st7262_par.c
@@ -13,6 +13,7 @@ bool direct_io_frame_trans_done(esp_lcd_panel_handle_t panel, esp_lcd_rgb_panel_
 
 void direct_io_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is not supported
     const esp_lcd_panel_handle_t panel_handle = display->user_data;
 
     lv_display_rotation_t rotation = lv_display_get_rotation(display);
@@ -67,10 +68,6 @@ lv_display_t *lvgl_lcd_init()
     uint32_t drawBufferSize = px_size * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is not supported
-    //display->sw_rotate = 1;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create direct_io panel handle
     const esp_lcd_rgb_panel_config_t rgb_panel_config = {

--- a/src/lvgl_panel_st7701_par.c
+++ b/src/lvgl_panel_st7701_par.c
@@ -16,8 +16,47 @@ bool direct_io_frame_trans_done(esp_lcd_panel_handle_t panel, esp_lcd_rgb_panel_
 void direct_io_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
     const esp_lcd_panel_handle_t panel_handle = display->user_data;
-    // LV_COLOR_16_SWAP is handled by mapping of the data
-    ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, area->x1, area->y1, area->x2 + 1, area->y2 + 1, px_map));
+
+    lv_display_rotation_t rotation = lv_display_get_rotation(display);
+    if (rotation == LV_DISPLAY_ROTATION_0)
+    {
+        ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, area->x1, area->y1, area->x2 + 1, area->y2 + 1, px_map));
+        return;
+    }
+
+    // Rotated
+    int32_t w = lv_area_get_width(area);
+    int32_t h = lv_area_get_height(area);
+    lv_color_format_t cf = lv_display_get_color_format(display);
+    uint32_t px_size = lv_color_format_get_size(cf);
+    size_t buf_size = w * h * px_size;
+    log_v("alloc rotation buffer to: %u bytes", buf_size);
+    void *rotation_buffer = heap_caps_malloc(buf_size, LVGL_BUFFER_MALLOC_FLAGS);
+    assert(rotation_buffer != NULL);
+
+    uint32_t w_stride = lv_draw_buf_width_to_stride(w, cf);
+    uint32_t h_stride = lv_draw_buf_width_to_stride(h, cf);
+
+    switch (rotation)
+    {
+    case LV_DISPLAY_ROTATION_90:
+        lv_draw_sw_rotate(px_map, rotation_buffer, w, h, w_stride, h_stride, rotation, cf);
+        ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, area->y1, display->ver_res - area->x1 - w, area->y1 + h, display->ver_res - area->x1, rotation_buffer));
+        break;
+    case LV_DISPLAY_ROTATION_180:
+        lv_draw_sw_rotate(px_map, rotation_buffer, w, h, w_stride, w_stride, rotation, cf);
+        ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, display->hor_res - area->x1 - w, display->ver_res - area->y1 - h, display->hor_res - area->x1, display->ver_res - area->y1, rotation_buffer));
+        break;
+    case LV_DISPLAY_ROTATION_270:
+        lv_draw_sw_rotate(px_map, rotation_buffer, w, h, w_stride, h_stride, rotation, cf);
+        ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, display->hor_res - area->y2 - 1, area->x2 - w + 1, display->hor_res - area->y2 - 1 + h, area->x2 + 1, rotation_buffer));
+        break;
+    default:
+        assert(false);
+        break;
+    }
+
+    free(rotation_buffer);
 };
 
 lv_display_t *lvgl_lcd_init()
@@ -30,7 +69,7 @@ lv_display_t *lvgl_lcd_init()
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is not supported
-    display->sw_rotate = 1;
+    //display->sw_rotate = 1;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Install 3-wire SPI panel IO

--- a/src/lvgl_panel_st7701_par.c
+++ b/src/lvgl_panel_st7701_par.c
@@ -15,6 +15,7 @@ bool direct_io_frame_trans_done(esp_lcd_panel_handle_t panel, esp_lcd_rgb_panel_
 
 void direct_io_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is not supported
     const esp_lcd_panel_handle_t panel_handle = display->user_data;
 
     lv_display_rotation_t rotation = lv_display_get_rotation(display);
@@ -67,10 +68,6 @@ lv_display_t *lvgl_lcd_init()
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is not supported
-    //display->sw_rotate = 1;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Install 3-wire SPI panel IO
     esp_lcd_panel_io_3wire_spi_config_t io_3wire_spi_config = {

--- a/src/lvgl_panel_st7789_i80.c
+++ b/src/lvgl_panel_st7789_i80.c
@@ -14,6 +14,7 @@ bool st7789_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_i
 
 void st7789_lv_flush(lv_display_t *drv, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is supported
     const esp_lcd_panel_handle_t panel_handle = drv->user_data;
     uint32_t pixels = lv_area_get_size(area);
     uint16_t *p = (uint16_t *)px_map;
@@ -34,10 +35,6 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is supported
-    //display->sw_rotate = 0;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     pinMode(ST7789_RD_GPIO, OUTPUT);
     digitalWrite(ST7789_RD_GPIO, HIGH);

--- a/src/lvgl_panel_st7789_i80.c
+++ b/src/lvgl_panel_st7789_i80.c
@@ -36,7 +36,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is supported
-    display->sw_rotate = 0;
+    //display->sw_rotate = 0;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     pinMode(ST7789_RD_GPIO, OUTPUT);

--- a/src/lvgl_panel_st7789_spi.c
+++ b/src/lvgl_panel_st7789_spi.c
@@ -37,7 +37,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is supported
-    display->sw_rotate = 0;
+    //display->sw_rotate = 0;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus

--- a/src/lvgl_panel_st7789_spi.c
+++ b/src/lvgl_panel_st7789_spi.c
@@ -15,6 +15,7 @@ bool st7789_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_i
 
 void st7789_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is supported
     esp_lcd_panel_handle_t panel_handle = display->user_data;
     uint32_t pixels = lv_area_get_size(area);
     uint16_t *p = (uint16_t *)px_map;
@@ -35,10 +36,6 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is supported
-    //display->sw_rotate = 0;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus
     const spi_bus_config_t spi_bus_config = {

--- a/src/lvgl_panel_st7796_spi.c
+++ b/src/lvgl_panel_st7796_spi.c
@@ -38,7 +38,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     // Hardware rotation is supported
-    display->sw_rotate = 0;
+    //display->sw_rotate = 0;
     display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus

--- a/src/lvgl_panel_st7796_spi.c
+++ b/src/lvgl_panel_st7796_spi.c
@@ -16,6 +16,7 @@ bool st7796_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_i
 
 void st7796_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
+    // Hardware rotation is supported
     esp_lcd_panel_handle_t panel_handle = display->user_data;
     uint32_t pixels = lv_area_get_size(area);
     uint16_t *p = (uint16_t *)px_map;
@@ -36,10 +37,6 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     uint32_t drawBufferSize = sizeof(lv_color_t) * LVGL_BUFFER_PIXELS;
     void *drawBuffer = heap_caps_malloc(drawBufferSize, LVGL_BUFFER_MALLOC_FLAGS);
     lv_display_set_buffers(display, drawBuffer, NULL, drawBufferSize, LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-    // Hardware rotation is supported
-    //display->sw_rotate = 0;
-    display->rotation = LV_DISPLAY_ROTATION_0;
 
     // Create SPI bus
     const spi_bus_config_t spi_bus_config = {


### PR DESCRIPTION
Removed SW rotate flag that is no longer available in LVGL > 9.2.1
Adapted drivers to use software rotation where applicable.