### PR TITLE
Update lvgl_touch_xpt2046_spi.c

### DIFF
--- a/src/lvgl_touch_xpt2046_spi.c
+++ b/src/lvgl_touch_xpt2046_spi.c
@@ -3,7 +3,7 @@
 #include <esp32_smartdisplay.h>
 #include <esp_touch_xpt2046.h>
 #include <driver/spi_master.h>
-#include <driver/spi_common_internal.h>
+#include <esp_private/spi_common_internal.h>
 
 void xpt2046_lvgl_touch_cb(lv_indev_t *indev, lv_indev_data_t *data)
 {


### PR DESCRIPTION
### Change path for esp idf 5.5

Using esp32-smartdisplay with Platformio and pioarduino allows the use of esp-idf 5.5.
The path to spi_common_internal has changed in lvgl_touch_xpt2046_spi.c

Change made in the develop branch.

