### PR TITLE
fix(xpt2046) : Header was moved in ESP-IDF 5.x

### DIFF
--- a/src/lvgl_touch_xpt2046_spi.c
+++ b/src/lvgl_touch_xpt2046_spi.c
@@ -3,7 +3,7 @@
 #include <esp32_smartdisplay.h>
 #include <esp_touch_xpt2046.h>
 #include <driver/spi_master.h>
-#include <driver/spi_common_internal.h>
+#include <esp_private/spi_common_internal.h>
 
 void xpt2046_lvgl_touch_cb(lv_indev_t *indev, lv_indev_data_t *data)
 {


### PR DESCRIPTION
Hello, it seems that driver/spi_common_internal.h has been moved to esp_private/spi_common_internal.h in ESP-IDF 5.x