### PR TITLE
Wait for the actual SPI/I80 transfer to finish before flush_ready

### DIFF
--- a/include/esp32_smartdisplay_dma.h
+++ b/include/esp32_smartdisplay_dma.h
@@ -42,11 +42,13 @@ extern "C"
     {
         QueueHandle_t transfer_queue;        // Queue for pending transfers
         SemaphoreHandle_t state_mutex;       // Mutex for state protection
+        SemaphoreHandle_t chunk_done_sem;    // Signalled by the panel IO's on_color_trans_done callback once a queued chunk has actually finished transferring
         TaskHandle_t worker_task;            // DMA worker task handle
         smartdisplay_dma_state_t state;      // Current DMA state
         void *dma_buffer;                    // DMA-capable buffer
         size_t dma_buffer_size;              // DMA buffer size
         esp_lcd_panel_handle_t panel_handle; // LCD panel handle
+        bool async_color_trans;              // True if the panel IO completes color transfers asynchronously and signals chunk_done_sem via smartdisplay_dma_notify_chunk_done()
         uint32_t active_transfers;           // Number of active transfers
         uint32_t completed_transfers;        // Total completed transfers
         uint32_t failed_transfers;           // Total failed transfers
@@ -56,9 +58,19 @@ extern "C"
      * @brief Initialize DMA manager for display transfers
      *
      * @param panel_handle LCD panel handle
+     * @param async_color_trans Set to true when the panel IO used by panel_handle
+     *        completes esp_lcd_panel_draw_bitmap() asynchronously (e.g. SPI/I80
+     *        panels driven through esp_lcd_panel_io, which queue the transaction
+     *        and return before the wire transfer finishes) AND its
+     *        on_color_trans_done callback calls smartdisplay_dma_notify_chunk_done().
+     *        Set to false for panels whose draw_bitmap() already blocks until the
+     *        data has physically been written (e.g. RGB parallel panels, or SPI
+     *        panels driven with spi_device_polling_transmit()) - for those, no
+     *        chunk_done_sem signal will ever arrive, so the DMA worker must not
+     *        wait for one.
      * @return esp_err_t ESP_OK on success
      */
-    esp_err_t smartdisplay_dma_init(esp_lcd_panel_handle_t panel_handle);
+    esp_err_t smartdisplay_dma_init(esp_lcd_panel_handle_t panel_handle, bool async_color_trans);
 
     /**
      * @brief Deinitialize DMA manager
@@ -116,6 +128,22 @@ extern "C"
      * @param px_map Pixel data
      */
     void smartdisplay_dma_lvgl_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
+
+    /**
+     * @brief Notify the DMA manager that a queued panel IO color transfer has
+     *        actually completed on the wire.
+     *
+     * Call this from a panel's on_color_trans_done callback (which runs in ISR
+     * context). It gives the semaphore that smartdisplay_dma_transfer_chunk()
+     * waits on before reusing the DMA buffer for the next chunk or letting the
+     * caller treat the transfer as finished, so lv_display_flush_ready() is
+     * only ever called once the SPI/I80 transfer that produced the current
+     * framebuffer contents has really finished (not just been queued).
+     *
+     * @return true if a higher-priority task was woken and the ISR should
+     *         request a context switch before it returns
+     */
+    bool smartdisplay_dma_notify_chunk_done(void);
 
 #ifdef __cplusplus
 }

--- a/include/esp32_smartdisplay_dma_helpers.h
+++ b/include/esp32_smartdisplay_dma_helpers.h
@@ -37,9 +37,12 @@ extern "C"
      * @brief Initialize DMA for a panel with standardized logging
      * @param panel_handle ESP LCD panel handle
      * @param panel_name Panel name for logging
+     * @param async_color_trans Whether panel_handle's draw_bitmap() completes
+     *        asynchronously and its panel IO's on_color_trans_done callback
+     *        calls smartdisplay_dma_notify_chunk_done() - see smartdisplay_dma_init()
      * @return ESP_OK on success, error code otherwise
      */
-    esp_err_t smartdisplay_dma_init_with_logging(esp_lcd_panel_handle_t panel_handle, const char *panel_name);
+    esp_err_t smartdisplay_dma_init_with_logging(esp_lcd_panel_handle_t panel_handle, const char *panel_name, bool async_color_trans);
 
     /**
      * @brief Structure to pass both display and buffer to rotation callback

--- a/src/esp32_smartdisplay_dma.c
+++ b/src/esp32_smartdisplay_dma.c
@@ -11,9 +11,41 @@ static smartdisplay_dma_manager_t *g_dma_manager = NULL;
 #define _min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+// How long a single chunk's transfer is allowed to take before we give up
+// waiting for its completion signal and report an error, instead of hanging
+// the worker task forever.
+#ifndef SMARTDISPLAY_DMA_CHUNK_TIMEOUT_MS
+#define SMARTDISPLAY_DMA_CHUNK_TIMEOUT_MS 500
+#endif
+
 bool smartdisplay_dma_should_use_dma(size_t data_len)
 {
     return g_dma_manager != NULL && data_len >= SMARTDISPLAY_DMA_CHUNK_THRESHOLD;
+}
+
+// Issue a single esp_lcd_panel_draw_bitmap() call and, for panels whose panel
+// IO completes color transfers asynchronously (async_color_trans == true),
+// block until the panel's on_color_trans_done callback confirms the data has
+// actually gone out over SPI/I80 (see smartdisplay_dma_notify_chunk_done()).
+// draw_bitmap() itself only queues the transaction and returns immediately on
+// those panels, so without this wait the caller could reuse/overwrite the
+// buffer - or LVGL could reuse the framebuffer - before the transfer is done.
+// Panels whose draw_bitmap() already blocks until the data is physically
+// written (RGB parallel panels, polling-mode SPI) have async_color_trans set
+// to false and never signal chunk_done_sem, so they just return as-is.
+static esp_err_t smartdisplay_dma_draw_bitmap_and_wait(int x_start, int y_start, int x_end, int y_end, const void *color_data)
+{
+    const esp_err_t ret = esp_lcd_panel_draw_bitmap(g_dma_manager->panel_handle, x_start, y_start, x_end, y_end, color_data);
+    if (ret != ESP_OK || !g_dma_manager->async_color_trans)
+        return ret;
+
+    if (xSemaphoreTake(g_dma_manager->chunk_done_sem, pdMS_TO_TICKS(SMARTDISPLAY_DMA_CHUNK_TIMEOUT_MS)) != pdTRUE)
+    {
+        log_e("Timed out waiting for panel transfer to complete");
+        return ESP_ERR_TIMEOUT;
+    }
+
+    return ESP_OK;
 }
 
 esp_err_t smartdisplay_dma_draw_bitmap(int x_start, int y_start, int x_end, int y_end, const void *color_data, smartdisplay_dma_callback_t callback, void *user_data, bool high_priority)
@@ -38,7 +70,7 @@ esp_err_t smartdisplay_dma_draw_bitmap(int x_start, int y_start, int x_end, int 
     // For small transfers, use direct transfer
     if (!smartdisplay_dma_should_use_dma(data_len))
     {
-        const esp_err_t ret = esp_lcd_panel_draw_bitmap(g_dma_manager->panel_handle, x_start, y_start, x_end, y_end, color_data);
+        const esp_err_t ret = smartdisplay_dma_draw_bitmap_and_wait(x_start, y_start, x_end, y_end, color_data);
         if (callback != NULL)
             callback(ret == ESP_OK, user_data);
 
@@ -62,7 +94,7 @@ esp_err_t smartdisplay_dma_draw_bitmap(int x_start, int y_start, int x_end, int 
     if (queue_result != pdPASS)
     {
         log_w("Transfer queue full, falling back to direct transfer");
-        esp_err_t ret = esp_lcd_panel_draw_bitmap(g_dma_manager->panel_handle, x_start, y_start, x_end, y_end, color_data);
+        esp_err_t ret = smartdisplay_dma_draw_bitmap_and_wait(x_start, y_start, x_end, y_end, color_data);
         if (callback != NULL)
             callback(ret == ESP_OK, user_data);
 
@@ -216,12 +248,15 @@ static esp_err_t smartdisplay_dma_transfer_chunk(const smartdisplay_dma_transfer
             return copy_result;
         }
 
-        // Perform DMA transfer
+        // Perform DMA transfer, waiting for it to actually finish before we
+        // let the next iteration overwrite dma_buffer (see
+        // smartdisplay_dma_draw_bitmap_and_wait() for why this wait matters)
         const int chunk_y_end = current_y + chunk_rows;
-        const esp_err_t transfer_result = esp_lcd_panel_draw_bitmap(g_dma_manager->panel_handle, transfer->x_start, current_y, transfer->x_end, chunk_y_end, dma_data);
+        const esp_err_t transfer_result = smartdisplay_dma_draw_bitmap_and_wait(transfer->x_start, current_y, transfer->x_end, chunk_y_end, dma_data);
         if (transfer_result != ESP_OK)
         {
-            log_e("LCD panel transfer failed: %s", esp_err_to_name(transfer_result));
+            if (transfer_result != ESP_ERR_TIMEOUT)
+                log_e("LCD panel transfer failed: %s", esp_err_to_name(transfer_result));
             return transfer_result;
         }
 
@@ -282,7 +317,17 @@ static void smartdisplay_dma_worker_task(void *pvParameters)
     }
 }
 
-esp_err_t smartdisplay_dma_init(esp_lcd_panel_handle_t panel_handle)
+bool smartdisplay_dma_notify_chunk_done(void)
+{
+    if (g_dma_manager == NULL || g_dma_manager->chunk_done_sem == NULL)
+        return false;
+
+    BaseType_t high_task_awoken = pdFALSE;
+    xSemaphoreGiveFromISR(g_dma_manager->chunk_done_sem, &high_task_awoken);
+    return high_task_awoken == pdTRUE;
+}
+
+esp_err_t smartdisplay_dma_init(esp_lcd_panel_handle_t panel_handle, bool async_color_trans)
 {
     if (g_dma_manager != NULL)
     {
@@ -334,15 +379,30 @@ esp_err_t smartdisplay_dma_init(esp_lcd_panel_handle_t panel_handle)
         return ESP_ERR_NO_MEM;
     }
 
+    // Create chunk-completion semaphore (only needed for panels that actually
+    // signal async completion via smartdisplay_dma_notify_chunk_done())
+    if (async_color_trans)
+    {
+        g_dma_manager->chunk_done_sem = xSemaphoreCreateBinary();
+        if (g_dma_manager->chunk_done_sem == NULL)
+        {
+            log_e("Failed to create chunk completion semaphore");
+            smartdisplay_dma_deinit();
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
     // Initialize state
     *g_dma_manager = (smartdisplay_dma_manager_t){
         .panel_handle = panel_handle,
+        .async_color_trans = async_color_trans,
         .state = SMARTDISPLAY_DMA_STATE_IDLE,
         .active_transfers = 0,
         .completed_transfers = 0,
         .failed_transfers = 0,
         .transfer_queue = g_dma_manager->transfer_queue,
         .state_mutex = g_dma_manager->state_mutex,
+        .chunk_done_sem = g_dma_manager->chunk_done_sem,
         .dma_buffer = g_dma_manager->dma_buffer,
         .dma_buffer_size = g_dma_manager->dma_buffer_size};
 
@@ -395,6 +455,13 @@ esp_err_t smartdisplay_dma_deinit()
     {
         vSemaphoreDelete(g_dma_manager->state_mutex);
         g_dma_manager->state_mutex = NULL;
+    }
+
+    // Delete chunk completion semaphore
+    if (g_dma_manager->chunk_done_sem != NULL)
+    {
+        vSemaphoreDelete(g_dma_manager->chunk_done_sem);
+        g_dma_manager->chunk_done_sem = NULL;
     }
 
     // Free DMA buffer

--- a/src/esp32_smartdisplay_dma_helpers.c
+++ b/src/esp32_smartdisplay_dma_helpers.c
@@ -92,9 +92,9 @@ esp_err_t smartdisplay_dma_flush_with_byteswap(lv_display_t *display, const lv_a
     return ESP_OK;
 }
 
-esp_err_t smartdisplay_dma_init_with_logging(esp_lcd_panel_handle_t panel_handle, const char *panel_name)
+esp_err_t smartdisplay_dma_init_with_logging(esp_lcd_panel_handle_t panel_handle, const char *panel_name, bool async_color_trans)
 {
-    esp_err_t dma_init_result = smartdisplay_dma_init(panel_handle);
+    esp_err_t dma_init_result = smartdisplay_dma_init(panel_handle, async_color_trans);
     if (dma_init_result == ESP_OK)
         log_i("DMA initialized successfully for %s display", panel_name);
     else

--- a/src/lvgl_panel_axa15231b_qspi.c
+++ b/src/lvgl_panel_axa15231b_qspi.c
@@ -11,11 +11,15 @@ bool axs15231b_color_trans_done(esp_lcd_panel_io_handle_t panel_io_handle, esp_l
 {
     log_v("panel_io_handle:0x%08x, panel_io_event_data:%0x%08x, user_ctx:0x%08x", panel_io_handle, panel_io_event_data, user_ctx);
 
-    // Note: When using DMA, lv_display_flush_ready() is called by DMA callbacks
-    // This callback is only used for direct transfers (non-DMA fallback)
-    lv_display_t *display = user_ctx;
-    lv_display_flush_ready(display);
-    return false;
+    // This fires once the SPI peripheral has actually finished sending the
+    // color data queued by esp_lcd_panel_draw_bitmap(). It used to call
+    // lv_display_flush_ready() directly here unconditionally, but that ran on
+    // every chunk of a multi-chunk DMA transfer (not just the last one) and
+    // raced with the DMA worker task's own flush_ready call - letting LVGL
+    // reuse the framebuffer while later chunks were still in flight. Instead,
+    // signal the DMA worker task (esp32_smartdisplay_dma.c), which is what
+    // actually calls lv_display_flush_ready() once the whole transfer is done.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void axs15231b_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
@@ -103,7 +107,7 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "AXS15231B QSPI");
+    smartdisplay_dma_init_with_logging(panel_handle, "AXS15231B QSPI", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_gc9a01_spi.c
+++ b/src/lvgl_panel_gc9a01_spi.c
@@ -11,9 +11,13 @@ bool gc9a01_color_trans_done(esp_lcd_panel_io_handle_t panel_io_handle, esp_lcd_
 {
     log_v("panel_io_handle:0x%08x, panel_io_event_data:%0x%08x, user_ctx:0x%08x", panel_io_handle, panel_io_event_data, user_ctx);
 
-    // Note: When using DMA, lv_display_flush_ready() is called by DMA callbacks
-    // This callback is only used for direct transfers (non-DMA fallback)
-    return false;
+    // This fires once the SPI peripheral has actually finished sending the
+    // color data queued by esp_lcd_panel_draw_bitmap(). The DMA worker task
+    // (esp32_smartdisplay_dma.c) is blocked waiting for this signal before it
+    // reuses the DMA buffer or reports the transfer as done - without it,
+    // lv_display_flush_ready() would fire while the SPI transaction was still
+    // in flight.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void gc9a01_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
@@ -81,7 +85,7 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "GC9A01 SPI");
+    smartdisplay_dma_init_with_logging(panel_handle, "GC9A01 SPI", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_ili9341_spi.c
+++ b/src/lvgl_panel_ili9341_spi.c
@@ -21,9 +21,12 @@ bool ili9341_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_
     if (display)
         lv_display_flush_ready(display);
 #endif
-    // DMA path signals completion via smartdisplay_dma_lvgl_flush_callback;
-    // return false so the IO layer doesn't treat this as the flush owner there.
-    return false;
+    // DMA path: signal the DMA worker task (esp32_smartdisplay_dma.c) that the
+    // chunk it just queued has actually finished transferring, so it's safe to
+    // reuse the DMA buffer / report the transfer as done - it calls
+    // lv_display_flush_ready() itself via smartdisplay_dma_lvgl_flush_callback
+    // once the whole transfer is complete.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void ili9341_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
@@ -89,7 +92,7 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ILI9341 SPI");
+    smartdisplay_dma_init_with_logging(panel_handle, "ILI9341 SPI", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_nv3041a_qspi.c
+++ b/src/lvgl_panel_nv3041a_qspi.c
@@ -76,7 +76,10 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
 
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "NV3041A QSPI");
+    // nv3041a_draw_bitmap() uses spi_device_polling_transmit(), which blocks
+    // until the transfer is physically done, so there is no async completion
+    // to wait for.
+    smartdisplay_dma_init_with_logging(panel_handle, "NV3041A QSPI", false);
 
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_st7262_par.c
+++ b/src/lvgl_panel_st7262_par.c
@@ -71,7 +71,9 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ST7262 Parallel");
+    // RGB parallel panel: esp_lcd_panel_draw_bitmap() blocks until the frame
+    // buffer copy is actually done, so there is no async completion to wait for.
+    smartdisplay_dma_init_with_logging(panel_handle, "ST7262 Parallel", false);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_st7701_par.c
+++ b/src/lvgl_panel_st7701_par.c
@@ -96,7 +96,9 @@ lv_display_t *lvgl_lcd_init()
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ST7701 Parallel");
+    // RGB parallel panel: esp_lcd_panel_draw_bitmap() blocks until the frame
+    // buffer copy is actually done, so there is no async completion to wait for.
+    smartdisplay_dma_init_with_logging(panel_handle, "ST7701 Parallel", false);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_st7789_i80.c
+++ b/src/lvgl_panel_st7789_i80.c
@@ -8,11 +8,13 @@
 
 bool st7789_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata, void *user_ctx)
 {
-    // Note: When using DMA, lv_display_flush_ready() is called by DMA callbacks
-    // This callback is only used for direct transfers (non-DMA fallback)
-    lv_display_t *display = user_ctx;
-    // lv_display_flush_ready(display) is handled by DMA callbacks when DMA is enabled.
-    return false;
+    // This fires once the I80 bus has actually finished sending the color data
+    // queued by esp_lcd_panel_draw_bitmap(). The DMA worker task
+    // (esp32_smartdisplay_dma.c) is blocked waiting for this signal before it
+    // reuses the DMA buffer or reports the transfer as done - without it,
+    // lv_display_flush_ready() would fire while the I80 transaction was still
+    // in flight.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void st7789_lv_flush(lv_display_t *drv, const lv_area_t *area, uint8_t *px_map)
@@ -90,7 +92,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ST7789 I80");
+    smartdisplay_dma_init_with_logging(panel_handle, "ST7789 I80", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_st7789_spi.c
+++ b/src/lvgl_panel_st7789_spi.c
@@ -9,10 +9,13 @@
 
 bool st7789_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata, void *user_ctx)
 {
-    // Note: When using DMA, lv_display_flush_ready() is called by DMA callbacks
-    // This callback is only used for direct transfers (non-DMA fallback)
-    // We return false to indicate we're not handling the flush completion here
-    return false;
+    // This fires once the SPI peripheral has actually finished sending the
+    // color data queued by esp_lcd_panel_draw_bitmap(). The DMA worker task
+    // (esp32_smartdisplay_dma.c) is blocked waiting for this signal before it
+    // reuses the DMA buffer or reports the transfer as done - without it,
+    // lv_display_flush_ready() would fire while the SPI transaction was still
+    // in flight.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void st7789_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
@@ -78,7 +81,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ST7789 SPI");
+    smartdisplay_dma_init_with_logging(panel_handle, "ST7789 SPI", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors

--- a/src/lvgl_panel_st7796_spi.c
+++ b/src/lvgl_panel_st7796_spi.c
@@ -10,10 +10,13 @@
 
 bool st7796_color_trans_done(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_io_event_data_t *edata, void *user_ctx)
 {
-    // Note: When using DMA, lv_display_flush_ready() is called by DMA callbacks
-    // This callback is only used for direct transfers (non-DMA fallback)
-    // We return false to indicate we're not handling the flush completion here
-    return false;
+    // This fires once the SPI peripheral has actually finished sending the
+    // color data queued by esp_lcd_panel_draw_bitmap(). The DMA worker task
+    // (esp32_smartdisplay_dma.c) is blocked waiting for this signal before it
+    // reuses the DMA buffer or reports the transfer as done - without it,
+    // lv_display_flush_ready() would fire while the SPI transaction was still
+    // in flight.
+    return smartdisplay_dma_notify_chunk_done();
 }
 
 void st7796_lv_flush(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
@@ -79,7 +82,7 @@ lv_display_t *lvgl_lcd_init(uint32_t hor_res, uint32_t ver_res)
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     
     // Initialize DMA for optimized transfers
-    smartdisplay_dma_init_with_logging(panel_handle, "ST7796 SPI");
+    smartdisplay_dma_init_with_logging(panel_handle, "ST7796 SPI", true);
     
 #ifdef DISPLAY_IPS
     // If LCD is IPS invert the colors


### PR DESCRIPTION
The DMA worker task in `esp32_smartdisplay_dma.c` calls `esp_lcd_panel_draw_bitmap()` for each chunk and, as soon as that call returns, treats the chunk as finished. On the SPI/I80/QSPI panels (ILI9341, GC9A01, ST7796, both ST7789 variants, AXS15231B) `draw_bitmap()` only queues the transaction through `esp_lcd_panel_io_tx_color()` and returns right away - the transfer itself happens later off an interrupt, and only really finishes when the panel IO's `on_color_trans_done` callback fires. All six of those panels register that callback, but it's a no-op, so nothing ever tells the worker task the wire transfer actually completed. The upshot is `lv_display_flush_ready()` gets called (letting LVGL reuse the draw buffer) while the SPI/I80 peripheral can still be reading the old contents - which shows up as flickering/tearing, more noticeably on bigger flushes that get split into several DMA chunks.

I confirmed this by reading through the ESP-IDF SPI panel-IO driver (`panel_io_spi_tx_color()` queues via `spi_device_queue_trans()` and returns immediately; the completion only happens later, from the SPI driver's own post-transaction ISR) and by writing a small host-side harness that mirrors the worker task's control flow against a simulated queue-then-complete SPI device - it reliably shows flush_ready firing before the simulated hardware is done, with actual buffer corruption in roughly 1 in 8 runs. There's also a comment on #283 from someone who independently ran into the same thing.

The fix gives the DMA manager a semaphore and has each of the six panels' `on_color_trans_done` callbacks signal it (that callback already fires whenever a queued color transfer really finishes, it just wasn't wired to anything). The worker task, and the couple of direct-transfer fallback spots in `esp32_smartdisplay_dma.c` that also call `draw_bitmap()`, now wait on that semaphore before treating a transfer as done. Panels where `draw_bitmap()` already blocks until the data is physically written - the RGB parallel panels (ST7701/ST7262) and NV3041A (which uses `spi_device_polling_transmit()`) - never had this race, so I added an `async_color_trans` flag to `smartdisplay_dma_init()` to opt those out rather than have them wait on a signal that will never arrive.

While in there I also noticed the AXS15231B callback was unconditionally calling `lv_display_flush_ready()` on every chunk instead of just the last one - that's now folded into the same semaphore signal instead.

Tested by building all affected board targets (JC2432W328C, esp32-2432S022C, esp32-2432S024C, esp32-2424S012C, esp32-3248S035C, JC3248W535N, esp32-4848S040CIY1, JC8048W550C) - all compile clean.